### PR TITLE
[Add]public-customer-profile

### DIFF
--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,16 +1,37 @@
 class Public::CustomersController < ApplicationController
   def show
+    @customer = current_customer
   end
-  
+
   def edit
+    @customer = current_customer
   end
-  
+
   def update
+    @customer = current_customer
+    if @customer.update(customer_params)
+      redirect_to customer_path
+    else
+      render :edit
+    end
   end
-  
+
+
+
   def leave
   end
-  
+
   def withdrawal
+    @customer = current_customer
+    @customer.update(is_deleted: true)
+    reset_session
+    redirect_to root_path
   end
+
+  private
+
+  def customer_params
+    params.require(:customer).permit(:last_name, :first_name, :last_name_katakana, :first_name_katakana, :post_code, :address, :telephone_number, :email)
+  end
+
 end

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Public::SessionsController < Devise::SessionsController
+  before_action :reject_customer, only: [:create]
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in
@@ -18,11 +19,19 @@ class Public::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # protected
-  
+  protected
+
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+  def reject_customer
+    @customer = Customer.find_by(email: params[:customer][:email])
+      if @customer
+        if @customer.valid_password?(params[:customer][:password]) &&  @customer.is_deleted?
+        redirect_to new_customer_registration_path
+      end
+    end
+  end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -3,4 +3,8 @@ class Customer < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+         
+  def active_for_authentication?
+    super && (is_deleted == false)
+  end
 end

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -1,1 +1,102 @@
-customers#edit
+<div class="container mt-5">
+
+  <p style="width: 130px; background-color:#DDDDDD;" class="text-center offset-md-1">会員情報登録</p>
+  <br>
+  <%= form_with model: @customer, url: '/customer', method: :patch do |f| %>
+
+
+    <div class="form-field row">
+      <div class="col-lg-3">
+        <p>名前</p>
+      </div>
+
+      <div class="col-lg-1 text-right">
+        <%=f.label :last_name,"(姓)" %>
+      </div>
+      <div class="col-lg-3">
+        <%=f.text_field :last_name, :placeholder => "令和"%>
+      </div>
+
+      <div class="col-lg-1 text-right">
+        <%=f.label :last_name,"(名)" %>
+      </div>
+      <div class="col-lg-3">
+        <%=f.text_field :first_name, :placeholder => "道子"%>
+      </div>
+    </div>
+
+    <div class="form-field row">
+      <div class="col-lg-3">
+        <p>フリガナ</p>
+      </div>
+
+      <div class="col-lg-1 text-right">
+        <%=f.label :last_name_katakana,"(セイ)" %>
+      </div>
+      <div class="col-lg-3">
+        <%=f.text_field :last_name_katakana, :placeholder => "レイワ"%>
+      </div>
+
+      <div class="col-lg-1">
+        <%=f.label :first_name_katakana,"(メイ)" %>
+      </div>
+      <div class="col-lg-3">
+        <%=f.text_field :first_name_katakana, :placeholder => "ミチコ"%>
+      </div>
+    </div>
+
+
+
+    <div class="form-field row">
+      <div class="col-lg-4">
+        <%=f.label :post_code,"郵便番号（ハイフンなし）" %>
+      </div>
+      <div class="col-lg-4">
+        <%=f.text_field :post_code, :placeholder => "0000000"%>
+      </div>
+      <div class="col-lg-4">
+      </div>
+    </div>
+
+    <div class="form-field row">
+      <div class="col-lg-4">
+        <%= f.label :住所 %>
+      </div>
+      <div class="col-lg-8">
+        <%= f.text_field :address,class:"col-lg-10", placeholder: "東京都渋谷区代々木神園町0-0" %>
+      </div>
+    </div>
+
+
+    <div class="form-field row">
+      <div class="col-lg-4">
+        <%= f.label :電話番号 %>
+      </div>
+      <div class="col-lg-4">
+        <%= f.text_field :telephone_number, pattern: "[0-9]{10}", placeholder: "0000000000" %>
+      </div>
+    </div>
+
+    <div class="form-field row">
+      <div class="col-lg-4">
+        <%= f.label :メールアドレス %>
+      </div>
+      <div class="col-lg-4">
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "sample@example.com"%>
+      </div>
+      <div class="col-lg-4">
+      </div>
+    </div>
+
+
+    <div class="row">
+      <div class="col-lg-4">
+      </div>
+      <div class="m-3">
+        <%= f.submit "編集内容を保存", class: "btn btn-success", style: 'width: 300px; margin-right: 50px;' %>
+        <%= link_to "退会する", '/customer/leave', class: "btn btn-danger" %>
+      </div>
+    </div>
+  <% end %>
+
+</div>

--- a/app/views/public/customers/leave.html.erb
+++ b/app/views/public/customers/leave.html.erb
@@ -1,1 +1,18 @@
-customers#leave
+<dir class="container mx-auto col-8 " style="margin-top: 100px;">
+  <p style="text-align: center;">
+    <strong>本当に退会しますか？</strong>
+  </p>
+
+  <p style="text-align: center;">
+    退会すると、会員登録情報や</br>
+    これまでの購入履歴が閲覧できなくなります。</br>
+    退会する場合は、「退会する」をクリックしてください。</br>
+  </p>
+  <dir class="row justify-content-center p-0">
+    <dir class="p-0">
+      <%= link_to "退会しない", '/customer',class: "btn btn-primary",style: 'width: 200px; margin-right: 50px;' %>
+      <%= link_to "退会する", '/customer/withdrawal',method: :patch, class: "btn btn-danger",style: 'width: 200px;' %>
+    </dir>
+
+  </dir>
+</dir>

--- a/app/views/public/customers/show.html.erb
+++ b/app/views/public/customers/show.html.erb
@@ -1,1 +1,37 @@
-customers#show
+<dir class="p-5">
+
+  <p style="width: 130px; background-color:#DDDDDD;" class="text-center offset-md-1">マイページ</p>
+  <br>
+
+  <p><strong>登録情報</strong>　<%= link_to "編集する",'/customer/information/edit',class: "btn btn-success btn-sm" %></p>
+
+  <table border="1" height="300">
+    <tr>
+      <td style="background-color:#DDDDDD;">氏名</td>
+      <td><%= @customer.last_name %>　<%= @customer.first_name %></td>
+    </tr>
+    <tr>
+      <td style="background-color:#DDDDDD;">カナ</td>
+      <td><%= @customer.last_name_katakana %>  <%= @customer.first_name_katakana %></td>
+    </tr>
+    <tr>
+      <td style="background-color:#DDDDDD;">郵便番号</td>
+      <td><%= @customer.post_code %></td>
+    </tr>
+    <tr>
+      <td style="background-color:#DDDDDD;">住所</td>
+      <td class="pr-5"><%= @customer.address %></td>
+    </tr>
+    <tr>
+      <td style="background-color:#DDDDDD;">電話番号</td>
+      <td><%= @customer.telephone_number %></td>
+    </tr>
+    <tr>
+      <td class="pr-5" style="background-color:#DDDDDD;">メールアドレス</td>
+      <td><%= @customer.email %></td>
+    </tr>
+  </table>
+  <br>
+  <p><strong>配送先　</strong>　<%= link_to "一覧を見る",'/deliverie',class: "btn btn-primary btn-sm py-0" %></p>
+  <p><strong>注文履歴</strong>　<%= link_to "一覧を見る",'/deliverie',class: "btn btn-primary btn-sm py-0" %></p>
+</dir>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,22 +16,24 @@ Rails.application.routes.draw do
     resources :orders_details, only: [:update]
   end
 
-  root to: "public/homes#top"
-  get "/about" => "public/homes#about"
-  resources :items, only: [:index, :show]
-  resource :customers, only: [:show, :update] do
+  scope module: 'public' do
+    root to: "homes#top"
+    get "/about" => "homes#about"
+    resources :items, only: [:index, :show]
+    resource :customer, only: [:show, :update] do
     get 'information/edit' => "customers#edit", on: :collection
     get 'leave', on: :collection
     patch 'withdrawal', on: :collection
   end
-  resources :cart_items, only: [:index, :update, :destroy, :create] do
+    resources :cart_items, only: [:index, :update, :destroy, :create] do
     delete 'destroy_all', on: :collection
   end
-  resources :orders, only: [:new, :create, :index, :show] do
+    resources :orders, only: [:new, :create, :index, :show] do
     post 'confirm', on: :collection
     get 'completion', on: :collection
   end
-  resources :deliveries, only: [:index, :edit, :create, :update, :destroy]
+    resources :deliveries, only: [:index, :edit, :create, :update, :destroy]
+  end
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
view/public/customers/のマイページ、登録情報編集画面、退会確認画面の追加
customersコントローラーのshow、edit、update、leave、withdrawalの追加、およびストロングパラメーターの設定
customerモデル、sessionコントローラーに退会後ログインできない様にする機能を記述

customerのログイン・ログアウト機能の部分（registrationsコントローラー）と、会員情報などの画面（customersコントローラー）のURLが被っていた為（どちらもcustomersを使っていた）、
customersコントローラーのURLをcustomers→customerに変更した