### PR TITLE
[Fix]会員ヘッダーのログアウトのパス修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -71,7 +71,7 @@
                 </li>
                   
                 <li class="nav-item ml-3" style="border-style:solid; border-width:2px;">
-                  <%= link_to "ログアウト", '/',  method: :delete, class: 'nav-link', style: 'color: black;' %>
+                  <%= link_to "ログアウト", destroy_customer_session_path, method: :delete, class: 'nav-link', style: 'color: black;' %>
                 </li>
               </ul>
             </div>
@@ -103,7 +103,7 @@
                 </li>
                   
                 <li class="nav-item ml-3" style="border-style:solid; border-width:2px;">
-                  <%= link_to "ログアウト", '/',  method: :delete, class: 'nav-link', style: 'color: black;' %>
+                  <%= link_to "ログアウト", destroy_customer_session_path, method: :delete, class: 'nav-link', style: 'color: black;' %>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
会員ヘッダーのログアウトのパスを"/"から"destroy_customer_session_path"に変更