### PR TITLE
[Fix]管理者/itemレイアウト調整

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ItemsController < ApplicationController
   def index
-    @items = Item.all
+    @items = Item.page(params[:page]).per(10)
   end
   
   def new
@@ -10,6 +10,7 @@ class Admin::ItemsController < ApplicationController
   
   def create
     @item = Item.new(item_params)
+    @genres = Genre.all
     if @item.save
       redirect_to admin_items_path
     else

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,6 +11,7 @@ class Item < ApplicationRecord
 	validates :genre_id, presence: true
 	validates :price, presence: true
 	validates :price, numericality: { only_integer: true }
+	validates :image, presence: true
 
 
   def get_image(width, height)

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,7 +1,9 @@
 <div class='container my-3'>
   <div class='row'>
-    <div>
-      <h4 class="title ml-5 bg-light">商品編集</h4>
+    <div class="col-10 mx-auto">
+      <div class="d-flex justify-content-between mb-3 align-items-center">
+        <h4 class="title bg-light">商品編集</h4>
+      </div>
     </div>
   </div>
   
@@ -50,10 +52,8 @@
             <%= f.radio_button :is_sales, false %> 販売停止中
           </div>
         </div>
-        <div class="form-group row">
-          <div class="col-sm-9 offset-sm-3">
-            <%= f.submit "変更を保存", class: 'btn btn-success' %>
-          </div>
+        <div class="row d-flex justify-content-center">
+          <%= f.submit "変更を保存", class: 'btn btn-success' %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,14 +1,16 @@
 <div class='container my-3'>
   <div class='row'>
-    <div>
-      <h4 class="title ml-5 bg-light">商品一覧</h4>
-    </div>
-  </div>
-  
-  <div class='row'>
-    <div class="col-8 mx-auto">
+    <div class="col-10 mx-auto">
+      
+      <div class="d-flex justify-content-between mb-3 align-items-center">
+        <h4  class="title bg-light">商品一覧</h4>
+        <%= link_to new_admin_item_path do %>
+          <i class="fa-solid fa-plus fa-2xl rounded-circle p-2 shadow-sm"></i>
+        <% end %>
+      </div>
+      
       <table class="table">
-        <thead>
+        <thead class="table-light">
           <tr>
             <th>商品ID</th>
             <th>商品名</th>
@@ -29,6 +31,9 @@
           <% end %>
         </tbody>
       </table>
+      <div class="d-flex justify-content-center">
+        <%= paginate @items %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -1,7 +1,9 @@
 <div class='container my-3'>
   <div class='row'>
-    <div>
-      <h4 class="title ml-5 bg-light">商品新規登録</h4>
+    <div class="col-10 mx-auto">
+      <div class="d-flex justify-content-between mb-3 align-items-center">
+        <h4 class="title ml-5 bg-light">商品新規登録</h4>
+      </div>
     </div>
   </div>
   
@@ -50,10 +52,9 @@
             <%= f.radio_button :is_sales, false %> 販売停止中
           </div>
         </div>
-        <div class="form-group row">
-          <div class="col-sm-9 offset-sm-3">
-            <%= f.submit "新規登録", class: 'btn btn-success' %>
-          </div>
+        
+        <div class="row d-flex justify-content-center">
+          <%= f.submit "新規登録", class: 'btn btn-success' %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,14 +1,17 @@
 <div class='container my-3'>
   <div class='row'>
-    <div>
-      <h4 class="title ml-5 bg-light">商品詳細</h4>
+    <div class="col-10 mx-auto">
+      <div  class="d-flex mb-3">
+        <h4 class="title bg-light">商品詳細</h4>
+      </div>
     </div>
   </div>
+  
   <div class='row'>
-    <div class="col-sm-4">
-      <%= image_tag @item.image, width: "350" %>
+    <div class="col-md-4">
+      <%= image_tag @item.image, width: "100%" %>
     </div>
-    <div class="col-sm-8">
+    <div class="col-md-8">
       <table class="table-borderless">
         <tr>
           <th>商品名</th>
@@ -31,10 +34,11 @@
           <td><%= @item.is_sales ? "販売中" : "販売停止中" %></td>
         </tr>
       </table>
-      <p><%= link_to edit_admin_item_path(@item.id),class: 'btn btn-success' do %>
-      編集する
-      <% end %>
-      </p>
     </div>
+  </div>
+  <div class="row d-flex justify-content-center">
+    <%= link_to edit_admin_item_path(@item.id),class: 'btn btn-success mt-3' do %>
+    編集する
+    <% end %>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,12 @@ module NaganoCake
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    
+    # バリデーションエラーが発生した際labelがfield_with_errorsのdivタブで囲まれる事を防ぐ
+    config.action_view.field_error_proc = Proc.new do |html_tag, instance|
+      if instance.kind_of?(ActionView::Helpers::Tags::Label)
+        html_tag.html_safe
+      end
+    end
   end
 end


### PR DESCRIPTION
・管理者/商品一覧ページ
商品新規登録リンク作成、ページネーション実装、レイアウト調整、

・管理者/商品詳細ページ
レイアウト調整

・管理者/商品編集ページ
レイアウト調整

・管理者/商品新規登録ページ
商品画像を選択していないと投稿できないようバリデーション設定

・config/application.rb
バリデーションエラーが発生した際、labelが<div class="field_with_errors">で囲んだ状態になってレイアウトが崩れないよう記述