### PR TITLE
[Fix]管理者/商品新規登録後の画面遷移ページ変更

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -12,7 +12,7 @@ class Admin::ItemsController < ApplicationController
     @item = Item.new(item_params)
     @genres = Genre.all
     if @item.save
-      redirect_to admin_items_path
+      redirect_to admin_item_path(@item)
     else
       render :new
     end


### PR DESCRIPTION
・admin/itemsコントローラ
商品新規登録後の画面遷移を商品一覧ページから商品詳細ページに変更