### PR TITLE
[Fix]ジャンルとカートに遷移する実装の変更

### DIFF
--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -8,6 +8,7 @@ class Admin::GenresController < ApplicationController
     @genre = Genre.new(genre_params)
     if @genre.save
       @genres = Genre.all
+      redirect_to admin_genres_path
     else
       @genres = Genre.all
       render :error

--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -36,7 +36,7 @@ class Public::CartItemsController < ApplicationController
     end
 
     if @cart_item.save
-      redirect_to item_path(@cart_item.item), notice: '商品をカートに追加しました。'
+      redirect_to cart_items_path(@cart_item.item), notice: '商品をカートに追加しました。'
     else
       @item = Item.find(@cart_item.item_id)
 

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -43,7 +43,7 @@
           <th class="table-light col-sm-6">合計金額</th>
           <td class="col-sm-6"><%= @cart_items.sum(&:subtotal).to_s(:delimited) %></td>
         </table>
-        <%= link_to '買い物を続ける', items_path, class: "btn btn-primary" %>
+        <%= link_to '買い物を続ける', "/", class: "btn btn-primary" %>
         <div class="col d-flex justify-content-center">
           <%= link_to '情報入力に進む', new_order_path, class: "btn btn-success" %>
         </div>


### PR DESCRIPTION
新しくジャンルを追加するとリダイレクトされるように変更
カートに入れるをクリックするとカートに遷移するように変更
買い物を続けるをクリックするとトップ画面に遷移するように変更